### PR TITLE
fix(compat): correct min version to 252 (2025.2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Monokai Islands Theme Plugin
 
-JetBrains GoLand theme plugin combining Monokai color palette with Islands UI aesthetics. Gradle-based IntelliJ Platform plugin (since build 242, GoLand 2025.2+). Dark variant with automated generation from JSON palette definition.
+JetBrains GoLand theme plugin combining Monokai color palette with Islands UI aesthetics. Gradle-based IntelliJ Platform plugin (since build 252, GoLand 2025.2+). Dark variant with automated generation from JSON palette definition.
 
 ## Project Structure
 
@@ -125,7 +125,7 @@ tasks {
 **src/main/resources/META-INF/plugin.xml**:
 
 - `id`: `com.github.smykla.monokai-islands`
-- `since-build`: `242` (GoLand 2025.2+)
+- `since-build`: `252` (GoLand 2025.2+)
 - `themeProvider` declaration for dark variant
 
 ## Changelog & Release Notes

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ When enabled, the Markdown preview will use Monokai-themed colors for code block
 
 ## Compatibility
 
-- **IDE Version**: 2025.3+ (build 253+)
+- **IDE Version**: 2025.2+ (build 252+)
 - **Supported IDEs**: All JetBrains IDEs (GoLand, IntelliJ IDEA, WebStorm, PyCharm, etc.)
 
 ## Development

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -72,7 +72,7 @@ intellijPlatform {
         description = provider { extractPluginDescription() }
 
         ideaVersion {
-            sinceBuild = "242"
+            sinceBuild = "252"
             untilBuild = provider { null }
         }
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -12,7 +12,7 @@
     <!-- A displayed Vendor name or Organization ID displayed on the Plugins Page. -->
     <vendor url="https://github.com/smykla-labs" email="bart.smykla@konghq.com">Bart Smykla</vendor>
 
-    <idea-version since-build="242"/>
+    <idea-version since-build="252"/>
 
     <!-- Description of the plugin displayed on the Plugin Page and IDE Plugin Manager.
       Guidelines: https://plugins.jetbrains.com/docs/marketplace/best-practices-for-listing.html#plugin-description -->


### PR DESCRIPTION
## Motivation

PR #59 incorrectly set the minimum version to `build 242` (`2024.2`), which does not support the Islands theme. According to JetBrains documentation, the Islands theme was introduced in `2025.2` (`build 252`), not `2024.2`.

**Sources:**
- [Meet the Islands Theme – The New Default Look for JetBrains IDEs](https://blog.jetbrains.com/platform/2025/12/meet-the-islands-theme-the-new-default-look-for-jetbrains-ides/)
- [Islands Theme: The New Look Coming to JetBrains IDEs](https://blog.jetbrains.com/platform/2025/09/islands-theme-the-new-look-coming-to-jetbrains-ides/)

## Implementation information

Corrected the minimum build version from `242` to `252` across all files:

- `plugin.xml`: Changed `since-build` from `242` to `252`
- `build.gradle.kts`: Changed `sinceBuild` from `"242"` to `"252"`
- `README.md`: Updated compatibility section from `2025.3+` to `2025.2+`
- `CLAUDE.md`: Updated all version references from `2024.2` to `2025.2`

This ensures the theme only installs on IDEs that properly support the Islands theme system.